### PR TITLE
Fix typo in comment about worker role

### DIFF
--- a/worker/main.go
+++ b/worker/main.go
@@ -17,7 +17,7 @@ func main() {
 		log.Fatalln("unable to create Temporal client", err)
 	}
 	defer c.Close()
-	// This worker hosts both Worker and Activity functions
+	// This worker hosts both Workflow and Activity functions
 	w := worker.New(c, app.GreetingTaskQueue, worker.Options{})
 	w.RegisterWorkflow(app.GreetingWorkflow)
 	w.RegisterActivity(app.ComposeGreeting)


### PR DESCRIPTION
## What was changed
Just a slight change in a comment of the file `worker/main.go`.

## Why?
I think there is a mistake in the comment: a worker hosts both **Workflow** and Activity functions (and not **Worker** and Activity).

## Checklist
N/A